### PR TITLE
Improve reset behaviors

### DIFF
--- a/Time/Time.lua
+++ b/Time/Time.lua
@@ -870,6 +870,17 @@ function frame:CreateSettingsFrame()
       -- END MOD
 
       TimeDB.positionPoint = nil; TimeDB.positionRelPoint = nil; TimeDB.positionX = nil; TimeDB.positionY = nil
+      -- Restore minimap icon to default position
+      TimeDB.minimapAnchorPoint  = DEFAULTS.minimapAnchorPoint
+      TimeDB.minimapRelativePoint= DEFAULTS.minimapRelativePoint
+      TimeDB.minimapX            = DEFAULTS.minimapX
+      TimeDB.minimapY            = DEFAULTS.minimapY
+      if frame.minimapIcon then
+        frame.minimapIcon:ClearAllPoints()
+        frame.minimapIcon:SetPoint(TimeDB.minimapAnchorPoint, Minimap,
+                                   TimeDB.minimapRelativePoint,
+                                   TimeDB.minimapX, TimeDB.minimapY)
+      end
 
       fs:SetValue(TimeDB.fontSize)
       sd:SetChecked(TimeDB.showDate)
@@ -1101,6 +1112,10 @@ function frame:CreateSettingsFrame()
       TimeDB.weekSeconds  = 0
       TimeDB.monthSeconds = 0
       TimeDB.yearSeconds  = 0
+      TimeDB.dayDate  = date("%Y-%m-%d")
+      TimeDB.weekID   = date("%Y-%U")
+      TimeDB.monthID  = date("%Y-%m")
+      TimeDB.yearID   = date("%Y")
       frame.sessionStart = time()
       frame:UpdateTracking()
       print(addonName..": Tracking data reset.")

--- a/Time/Time.toc
+++ b/Time/Time.toc
@@ -1,4 +1,4 @@
-## Interface: 110105, 110107
+## Interface: 110105
 ## Title: Time
 ## Notes: Just a handy addon
 ## Author: Renvulf


### PR DESCRIPTION
## Summary
- fix multi-version interface field
- restore minimap icon on resetting defaults
- ensure tracking date fields reset correctly

## Testing
- `luac -p Time/Time.lua`
- `luacheck Time/Time.lua`

------
https://chatgpt.com/codex/tasks/task_e_685b2671a2588328aa9d33cceb3b0d81