### PR TITLE
Adjust wave checkbox position

### DIFF
--- a/Time/Time.lua
+++ b/Time/Time.lua
@@ -1060,7 +1060,8 @@ function frame:CreateSettingsFrame()
     end)
 
     -- Wave Checkbox (renamed from "Bounce")
-    local bc = CreateCheckbox(p, "TimeWaveCB", "Wave", 160, startY - 4*spacing, TimeDB.waveClock, function(self)
+    -- Shifted slightly upwards to avoid overlapping the Default button
+    local bc = CreateCheckbox(p, "TimeWaveCB", "Wave", 160, startY - 4*spacing + 20, TimeDB.waveClock, function(self)
       TimeDB.waveClock = self:GetChecked()
       frame:ApplySettings()
     end)


### PR DESCRIPTION
## Summary
- adjust Wave tickbox placement in Clock Settings so it sits higher than the Default button

## Testing
- `lua -v` *(fails: command not found)*
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b79653d348328a0c332588a176d06