### PR TITLE
Fix wave checkbox overlapping default button

### DIFF
--- a/Time/Time.lua
+++ b/Time/Time.lua
@@ -1116,7 +1116,8 @@ function frame:CreateSettingsFrame()
     end)
 
     -- Wave Checkbox (renamed from "Bounce") aligned with other options
-    local bc = CreateCheckbox(p, "TimeWaveCB", "Wave", 160, startY - 4*spacing, TimeDB.waveClock, function(self)
+    -- Moved up to avoid overlapping the Default button
+    local bc = CreateCheckbox(p, "TimeWaveCB", "Wave", 160, startY - 3*spacing, TimeDB.waveClock, function(self)
       TimeDB.waveClock = self:GetChecked()
       frame:ApplySettings()
     end)


### PR DESCRIPTION
## Summary
- adjust Wave checkbox placement so it no longer overlaps the Default button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b8273343c83289bbfda63bdfc1376