### PR TITLE
Add alarm slash command and README updates

### DIFF
--- a/Time/README.md
+++ b/Time/README.md
@@ -15,5 +15,18 @@ Time is a lightweight World of Warcraft addon that provides a customizable clock
 ## Usage
 Install the addon in your `Interface/AddOns` directory and type `/time` in game to open the settings window. Hover the minimap icon or the LDB entry to view tracked play time. Drag the clock or minimap icon while "Tick to move" is enabled.
 
+## Commands
+Use these chat commands for quick actions:
+
+* `/time` – toggle the configuration window.
+* `/time alarm HH:MM [AM|PM] [message]` – set an alarm with an optional reminder message. Accepts both 24‑hour and 12‑hour formats.
+  * Examples:
+    * `/time alarm 07:30 Wake up!`
+    * `/time alarm 7:30 AM Morning dungeon`
+* `/time remind me in <number>[s|m|h|d] <message>` – show a toast reminder after the specified delay.
+  * Example: `/time remind me in 5m Check the auction house`
+
+If an alarm triggers, a fullscreen overlay with your reminder text and an alarm sound will appear. Reminders created with the `remind me in` command appear as small toasts near the top‑right of the screen.
+
 ## License
 This project is released under the MIT License. See `LICENSE` for details.

--- a/Time/Time.lua
+++ b/Time/Time.lua
@@ -1617,6 +1617,41 @@ SlashCmdList["TIME"] = function(msg)
     return
   end
 
+  -- Check for an alarm command in the format "alarm HH:MM [AM/PM] [reminder]"
+  local h, m, ap, reminder = cmd:match("^alarm%s+(%d?%d):(%d%d)%s*(%a%a)?%s*(.*)$")
+  if h then
+    local hour = tonumber(h)
+    local min  = tonumber(m)
+    ap = ap and ap:upper() or nil
+    -- validate minutes
+    if min < 0 or min > 59 then
+      print(addonName..": Invalid minutes. Must be 00-59.")
+      return
+    end
+    -- handle 12h or 24h input
+    if ap == "AM" or ap == "PM" then
+      if hour < 1 or hour > 12 then
+        print(addonName..": Invalid hour for 12h format. Use 1-12.")
+        return
+      end
+      if ap == "PM" and hour < 12 then hour = hour + 12 end
+      if ap == "AM" and hour == 12 then hour = 0 end
+    else
+      if hour < 0 or hour > 23 then
+        print(addonName..": Invalid hour for 24h format. Use 0-23.")
+        return
+      end
+    end
+
+    TimeDB.alarmTime = string.format("%02d:%02d", hour, min)
+    TimeDB.alarmReminder = strtrim(reminder or "")
+    print(addonName..": Alarm time set to "..TimeDB.alarmTime)
+    if TimeDB.alarmReminder ~= "" then
+      print(addonName..": Reminder text set to '"..TimeDB.alarmReminder.."'.")
+    end
+    return
+  end
+
   print(addonName..": unknown command")
 end
 


### PR DESCRIPTION
## Summary
- support `/time alarm` slash command for quickly setting an alarm from chat
- document available chat commands in README

## Testing
- `luac -p Time/Time.lua` *(fails: command not found)*
- `luacheck Time/Time.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9274986c832897459ff41d8e7739