### PR TITLE
Improve alarm handling

### DIFF
--- a/Time/README.md
+++ b/Time/README.md
@@ -5,7 +5,7 @@ Time is a lightweight World of Warcraft addon that provides a customizable clock
 ## Features
 - Movable clock display with configurable font, color and size
 - Optional date, seconds, server time and hourly chime
-- Alarm with custom reminder text and fullscreen notification
+- Alarm with custom reminder text, adjustable duration and fullscreen notification
 - Playtime tracking (session/day/week/month/year) shown in tooltips
 - Quality of life options for the Objective Tracker
 - Combat text configuration including font overrides


### PR DESCRIPTION
## Summary
- add optional alarm duration to defaults and settings panel
- auto-stop alarms after configurable duration
- update README about adjustable alarm duration

## Testing
- `lua` tests *(none)*

------
https://chatgpt.com/codex/tasks/task_e_685bace4cd248328904c9b69e9c3e8a5