### PR TITLE
Fix combat font preview refresh

### DIFF
--- a/Time/Time.lua
+++ b/Time/Time.lua
@@ -1813,7 +1813,13 @@ function frame:CreateSettingsFrame()
               TimePerCharDB.combatFont = relative
               UIDropDownMenu_SetText(dd, dispCopy)
               SetCombatPreviewFont(fontObj, pathCopy)
-              preview:SetText(editBox:GetText())
+              -- BEGIN FIX: force preview to redraw when font stays the same
+              -- WoW's UI may skip layout if text hasn't changed; clearing then
+              -- resetting ensures the new font actually renders.
+              local txt = editBox:GetText()
+              preview:SetText("")
+              preview:SetText(txt)
+              -- END FIX
             end
             info.checked = (TimePerCharDB.combatFont == fontData.relative)
             UIDropDownMenu_AddButton(info)


### PR DESCRIPTION
## Summary
- ensure combat font dropdown preview always refreshes

## Testing
- `luac -p Time/Time.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c080f6ce48328a549a73697ada048